### PR TITLE
Timeout

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -268,9 +268,9 @@ function islandora_large_image_create_tn_derivative(AbstractObject $object, $for
           ];
         }
       }
+      file_unmanaged_delete($derivative_file);
     }
     file_unmanaged_delete($uploaded_file);
-    file_unmanaged_delete($derivative_file);
     return $to_return;
   }
 }

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -382,7 +382,7 @@ function islandora_large_image_imagemagick_convert($src, $dest, array $raw_argum
   $output = '';
   $ret = -1;
   try {
-    $exec_manager->setTimeout(null);
+    $exec_manager->setTimeout(NULL);
     if ($exec_manager->execute($command, $arguments, $output, $ret) !== TRUE) {
       $variables = [
         '@ret' => $ret,

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -381,16 +381,21 @@ function islandora_large_image_imagemagick_convert($src, $dest, array $raw_argum
   \Drupal::moduleHandler()->alter('imagemagick_arguments', $arguments, $command);
   $output = '';
   $ret = -1;
-  if ($exec_manager->execute($command, $arguments, $output, $ret) !== TRUE) {
-    $variables = [
-      '@ret' => $ret,
-      '@args' => implode('<br/>', $arguments->getArguments()),
-      '@output' => $output,
-    ];
-    \Drupal::logger('islandora_large_image')->error('ImageMagick failed to convert.<br/>Error: @ret<br/>Args: @args <br/>Output @output', $variables);
-    return FALSE;
+  try {
+    $exec_manager->setTimeout(null);
+    if ($exec_manager->execute($command, $arguments, $output, $ret) !== TRUE) {
+      $variables = [
+        '@ret' => $ret,
+        '@args' => implode('<br/>', $arguments->getArguments()),
+        '@output' => $output,
+      ];
+      \Drupal::logger('islandora_large_image')->error('ImageMagick failed to convert.<br/>Error: @ret<br/>Args: @args <br/>Output @output', $variables);
+      return FALSE;
+    }
+    return $dest;
+  } finally {
+    $exec_manager->setTimeout(60);
   }
-  return $dest;
 }
 
 /**


### PR DESCRIPTION
Imagemagick has a [timeout](https://git.drupalcode.org/project/imagemagick/blob/8.x-2.x/src/ImagemagickExecManager.php#L39) that could cause issues with large images, so this gets rid of the timeout while processing a large image, and resets it afterward.